### PR TITLE
expand "tzset" response

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -60,7 +60,7 @@ async def set_zone(ctx, *, timezone):
     user_zone.zone = zone
     session.commit()
 
-    await ctx.send("Set to **%s**" % zone)
+    await ctx.send("Set your time zone to **%s**" % zone)
 
 
 def query_zone(user: discord.Member):


### PR DESCRIPTION
Added wording to the `tzset` command to indicate the user's time zone is being update, and not making it seem like a server-based change for users that may not be familiar with the system.