### PR TITLE
Set author to default "time" user

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -93,7 +93,7 @@ async def info_error(ctx, error):
 @bot.command(name='tzget')
 async def get_zone(ctx, users: commands.Greedy[discord.Member]):
     if len(users) == 0:
-        return await ctx.send("You must mention at least one user")
+        users = [ctx.author]
 
     await ctx.send('\n'.join([
         '%s: **%s**' % (user.nick or user.name,

--- a/bot.py
+++ b/bot.py
@@ -105,7 +105,7 @@ async def get_zone(ctx, users: commands.Greedy[discord.Member]):
 @bot.command(name='time')
 async def get_time(ctx, users: commands.Greedy[discord.Member]):
     if len(users) == 0:
-        return await ctx.send("You must mention at least one user")
+        users = [ctx.author]
 
     await ctx.send('\n'.join([
         '%s: **%s**' % (user.nick or user.name,


### PR DESCRIPTION
If there is no user tagged on the `time` command, have it post the current time for the user that ran the command.